### PR TITLE
fix background image on standalone pages

### DIFF
--- a/src/components/BlogComponents/BlogHero.jsx
+++ b/src/components/BlogComponents/BlogHero.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import Hero from '../../components/Hero';
 import Container from '../../components/Container';
 import { H1 } from '../../components/Typography';
+import { theme } from '../../utils/styles';
 
 const StyledHero = styled(Hero)`
   ${({ theme }) => theme.media.xlLarge`
@@ -17,7 +18,7 @@ const StyledHero = styled(Hero)`
 `;
 
 const BlogHero = () => (
-  <StyledHero themeName="sea">
+  <StyledHero theme={{...theme, currentTheme: theme.sea}}>
     <Container>
       <H1>Video JS Blog</H1>
     </Container>

--- a/src/components/GettingStartedComponents/GettingStartedHero.jsx
+++ b/src/components/GettingStartedComponents/GettingStartedHero.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import Hero from '../../components/Hero';
 import Container from '../../components/Container';
 import { H1, H2 } from '../../components/Typography';
+import { theme } from '../../utils/styles';
 
 const StyledH2 = styled(H2)`
   letter-spacing: -0.01em;
@@ -25,7 +26,7 @@ const StyledHero = styled(Hero)`
 `;
 
 const GettingStartedHero = () => (
-  <StyledHero themeName="fantasy">
+  <StyledHero theme={{...theme, currentTheme: theme.fantasy}}>
     <Container>
       <H1>Getting Started</H1>
       <StyledH2>

--- a/src/components/PluginsComponents/PluginsHero.jsx
+++ b/src/components/PluginsComponents/PluginsHero.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import Hero from '../../components/Hero';
 import Container from '../../components/Container';
 import { H1, H2 } from '../../components/Typography';
+import { theme } from '../../utils/styles';
 
 const StyledH2 = styled(H2)`
   letter-spacing: -0.01em;
@@ -25,7 +26,7 @@ const StyledHero = styled(Hero)`
 `;
 
 const PluginsHero = () => (
-  <StyledHero themeName="forest">
+  <StyledHero theme={{...theme, currentTheme: theme.forest}}>
     <Container>
       <H1>Plugins and Skins</H1>
       <StyledH2>


### PR DESCRIPTION
We discussed that the code no longer pass around `themeName`. Instead we pass the whole theme object. Doing this inadvertently broke the standalone pages.