### PR TITLE
Dj/responsive bugfixes

### DIFF
--- a/src/components/BlogComponents/BlogHero.jsx
+++ b/src/components/BlogComponents/BlogHero.jsx
@@ -7,6 +7,9 @@ import { H1 } from '../../components/Typography';
 import { theme } from '../../utils/styles';
 
 const StyledHero = styled(Hero)`
+  ${Container} {
+    padding-bottom: 2.5em;
+  }
   ${({ theme }) => theme.media.xlLarge`
     background-position: center -670px;
 

--- a/src/components/BlogComponents/BlogLayout.jsx
+++ b/src/components/BlogComponents/BlogLayout.jsx
@@ -10,18 +10,30 @@ import BlogTags from './BlogTags';
 import BlogRecentPosts from './BlogRecentPosts';
 
 const StyledContainer = styled(Container)`
-  display: flex;
-  justify-content: space-between;
-  margin-top: 7em;
+  margin-top: 2em;
+  ${({ theme }) => theme.media.medLarge`
+    margin: 7em 0 0 0;
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: space-between;
+  `}
 `;
 
 const PostWrapper = styled.div`
-  width: 74%;
-  padding-right: 3em;
+  margin: 0 2em;
+  ${({ theme }) => theme.media.medLarge`
+    padding-right: 3em;
+    margin: 0;
+    width: 74%;
+  `}
 `;
 
 const Sidebar = styled.aside`
-  width: 19%;
+  display: none;
+  ${({ theme }) => theme.media.medLarge`
+    display: block;
+    width: 19%;
+  `}
 `;
 
 const BlogLayout = ({ children, seo }) => (
@@ -29,13 +41,13 @@ const BlogLayout = ({ children, seo }) => (
     <SEO {...seo} />
     <BlogHero />
     <StyledContainer>
-      <PostWrapper>
-        {children}
-      </PostWrapper>
       <Sidebar>
         <BlogTags />
         <BlogRecentPosts />
       </Sidebar>
+      <PostWrapper>
+        {children}
+      </PostWrapper>
     </StyledContainer>
   </Layout>
 );

--- a/src/components/BlogComponents/BlogPagination.jsx
+++ b/src/components/BlogComponents/BlogPagination.jsx
@@ -7,7 +7,9 @@ import Link from '../Link';
 const BlogPaginationWrapper = styled.div`
   display: flex;
   justify-content: space-between;
-  padding-left: 4.375em;
+  ${({ theme }) => theme.media.medLarge`
+    padding-left: 4.375em;
+  `}
   margin-bottom: 3em;
 `;
 

--- a/src/components/BlogComponents/BlogPost.jsx
+++ b/src/components/BlogComponents/BlogPost.jsx
@@ -20,8 +20,12 @@ const Wrapper = styled.article`
 `;
 
 const AvatarCol = styled.div`
-  flex: 0 1 auto;
-  margin-right: 1.25em;
+  display: none;
+  ${({ theme }) => theme.media.medLarge`
+    display: block;
+    flex: 0 1 auto;
+    margin-right: 1.25em;
+  `}
 `;
 
 const Avatar = styled.img`
@@ -35,7 +39,10 @@ const Avatar = styled.img`
 
 const TextCol = styled.div`
   flex: 1 1 auto;
-  max-width: calc(100% - 4.375em);
+  max-width: 100%;
+  ${({ theme }) => theme.media.medLarge`
+    max-width: calc(100% - 4.375em);
+  `}
 `;
 
 const Meta = styled.div`
@@ -47,6 +54,12 @@ const Meta = styled.div`
   font-weight: 300;
   height: 2.78em;
   margin-bottom: 1.5em;
+  ${Link} {
+   display: block;
+   ${({ theme }) => theme.media.medLarge`
+      display: none;
+   `}
+  }
 `;
 
 const Text = styled.div`
@@ -88,19 +101,24 @@ const TitleLink = styled(Link)`
   color: #000;
 `;
 
+const AvatarLink = ({ github }) => (
+  <Link
+    href={getAuthorProfile(github)}
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    <Avatar src={getAuthorAvatar(github)} />
+  </Link>
+)
+
 const BlogPost = ({ post: { frontmatter, code, fields } }) => (
   <Wrapper>
     <AvatarCol>
-      <Link
-        href={getAuthorProfile(frontmatter.author.github)}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <Avatar src={getAuthorAvatar(frontmatter.author.github)} />
-      </Link>
+      <AvatarLink github={frontmatter.author.github} />
     </AvatarCol>
     <TextCol>
       <Meta>
+        <AvatarLink github={frontmatter.author.github} />
         <span>{frontmatter.author.name}</span>
         <span>{frontmatter.date}</span>
       </Meta>

--- a/src/components/HomeComponents/AdvancedExample/PlayerControls.jsx
+++ b/src/components/HomeComponents/AdvancedExample/PlayerControls.jsx
@@ -7,13 +7,19 @@ import RangeInput from '../../RangeInput';
 const Form = styled.form`
   background-color: #fff;
   border: 0.125em solid #ebebeb;
-  position: absolute;
-  top: 0;
-  left: 0;
   height: 14.57em;
-  width: 19.94em;
+  width: 90%;
   padding: 1.5em;
+  margin: 0 auto 1.5em auto;
   z-index: 1;
+
+  ${({ theme }) => theme.media.medLarge`
+    position: absolute;
+    top: 0;
+    left: 0;
+    margin: 0;
+    width: 19.94em;
+  `}
 
   ${({ theme }) => theme.media.medLarge`
     top: -2em;

--- a/src/components/HomeComponents/AdvancedExample/PlayerPlaylist.jsx
+++ b/src/components/HomeComponents/AdvancedExample/PlayerPlaylist.jsx
@@ -2,8 +2,14 @@ import React from 'react';
 import styled from 'styled-components';
 
 const PlaylistWrapper = styled.div`
-  flex: 1 1 25%;
+  height: 25em;
   position: relative;
+  margin: 3.5em;
+
+  ${({ theme }) => theme.media.medLarge`
+    flex: 1 1 25%;
+    margin: 0;
+  `}
 
   .vjs-playlist {
     background: transparent;

--- a/src/components/HomeComponents/AdvancedExample/index.jsx
+++ b/src/components/HomeComponents/AdvancedExample/index.jsx
@@ -17,29 +17,33 @@ import playlist from './playlist';
 
 import rectangles from '../../../images/footer-rectangles.svg';
 
-const AdvancedExampleContainer = styled.div`
-  display: none;
-
-  ${({ theme }) => theme.media.xLarge`
-    display: block;
-  `}
-`;
+const AdvancedExampleContainer = styled.div``;
 
 const PlaylistPluginDescContainer = styled(Container)`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  margin-bottom: 2.2em;
-
-  > * {
-    width: 33%;
+  margin-top: 1.5em;
+  p {
+    padding: 0 2.5em;
   }
+  ${({ theme }) => theme.media.medLarge`
+    margin-top: 0;
+    p {
+      padding: 0;
+    }
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    margin-bottom: 2.2em;
 
-  & {
-    ${({ theme }) => theme.media.xLarge`
-      padding-top: 12.5em;
-    `}
-  }
+    > * {
+      width: 33%;
+    }
+
+    & {
+      ${({ theme }) => theme.media.xLarge`
+        padding-top: 12.5em;
+      `}
+    }
+ `}
 `;
 
 const StyledSectionHeader = styled(SectionHeader)`
@@ -63,10 +67,12 @@ const ControlsWrapper = styled.div`
 `;
 
 const VideoWrapper = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
   margin-bottom: 1.25em;
+  ${({ theme }) => theme.media.medLarge`
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+  `}
 `;
 
 const Video = styled.video`

--- a/src/pages/advanced.jsx
+++ b/src/pages/advanced.jsx
@@ -7,7 +7,7 @@ import AdvancedHero from '../components/AdvancedComponents/AdvancedHero';
 
 const AdvancedPage = () => (
   <Layout>
-    <SEO title="advanced/index - Video.js: The Player Framework" />
+    <SEO title="Video.js - Make your player yours" />
     <AdvancedHero />
     <AdvancedExample enableThemeQueryParam hideDescription />
   </Layout>

--- a/src/templates/BlogListTemplate.jsx
+++ b/src/templates/BlogListTemplate.jsx
@@ -1,11 +1,20 @@
 import React from 'react';
 import shortid from 'shortid';
+import styled from 'styled-components';
 import { graphql } from 'gatsby';
 
 import BlogLayout from '../components/BlogComponents/BlogLayout';
 import BlogPost from '../components/BlogComponents/BlogPost';
 import BlogPagination from '../components/BlogComponents/BlogPagination';
+import BlogTags from '../components/BlogComponents/BlogTags';
+import BlogRecentPosts from '../components/BlogComponents/BlogRecentPosts';
 import { extractNodes } from '../utils/graphql';
+
+const BottomPanels = styled.div`
+  ${({ theme }) => theme.media.medLarge`
+    display: none;
+  `}
+`
 
 const BlogListTemplate = ({
   data: { allMdx },
@@ -18,6 +27,10 @@ const BlogListTemplate = ({
       {posts.map(post => (
         <BlogPost key={shortid.generate()} post={post} />
       ))}
+      <BottomPanels>
+        <BlogTags />
+        <BlogRecentPosts />
+      </BottomPanels>
       <BlogPagination
         prevLink={prevPage}
         prevLinkCaption="Prev page"


### PR DESCRIPTION
Knocking off these tasks:

![image (1)](https://user-images.githubusercontent.com/764988/65725368-51caa880-e067-11e9-8a4a-a0e47f53edd0.png)

## Advanced Page (also applies to the home page advanced section)

  * Update SEO title to: `Video.js - Make your player yours`
  * For the smaller screen sizes, I chose to stack the controls on top, followed by the video, followed by the playlist and then finally the media info panel

![adv-1_2019-09-26_13-22-55](https://user-images.githubusercontent.com/764988/65724934-60649000-e066-11e9-9b31-fccfad152492.png)

---- 

![adv-2_2019-09-26_13-23-03](https://user-images.githubusercontent.com/764988/65724938-622e5380-e066-11e9-8b7e-4a504a281193.png)

---- 

![adv-3_2019-09-26_13-23-19](https://user-images.githubusercontent.com/764988/65724943-635f8080-e066-11e9-8f98-3a13d36fe3fa.png)

## Blog Page

  * ~For the smaller screen sizes, I chose to move the "Tags" and "Recent Posts" panels above the blog content.~
  * ~One alternative to this would be to put them below the blog content, but on the blog home page there are a lot of posts so that would be really far down the page~
  * ~Another alternative is to simply not show the "Tags" and "Recent Posts" panels on smaller screens, but I think we want to show this.~
  * **update** I moved the "tags" and "recent posts" panels to the bottom, above the pagination


![blog-4_2019-09-26_14-31-15](https://user-images.githubusercontent.com/764988/65726609-547acd00-e06a-11e9-868d-55f299be9cdc.png)

----

![tags-recents-to-bottom](https://user-images.githubusercontent.com/764988/65726563-3c0ab280-e06a-11e9-824c-e4c19cebd437.gif)

