### PR TITLE
responsive getting started page and set google analytics cookie to 0

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -57,6 +57,7 @@ module.exports = {
       resolve: `gatsby-plugin-google-analytics`,
       options: {
         trackingId: 'UA-16505296-1',
+        cookieExpires: 0,
       },
     },
     // this (optional) plugin enables Progressive Web App + Offline functionality

--- a/src/components/GettingStartedComponents/GettingStartedArticle.jsx
+++ b/src/components/GettingStartedComponents/GettingStartedArticle.jsx
@@ -6,7 +6,10 @@ import MDXRenderer from 'gatsby-mdx/mdx-renderer';
 import WithMdxComponents from '../WithMdxComponents';
 
 const Wrapper = styled.article`
-  width: 76%;
+  width: 100%;
+  ${({ theme }) => theme.media.medLarge`
+    width: 76%;
+  `}
 
   h2, h3 {
     font-size: 28px;

--- a/src/components/GettingStartedComponents/GettingStartedHero.jsx
+++ b/src/components/GettingStartedComponents/GettingStartedHero.jsx
@@ -12,6 +12,10 @@ const StyledH2 = styled(H2)`
   line-height: 1.5;
   max-width: 33em;
   margin: 0 auto;
+  padding: 2em 1em;
+  ${({ theme }) => theme.media.medLarge`
+    padding: 0;
+  `}
 `;
 
 const StyledHero = styled(Hero)`

--- a/src/components/GettingStartedComponents/GettingStartedNav.jsx
+++ b/src/components/GettingStartedComponents/GettingStartedNav.jsx
@@ -6,52 +6,56 @@ import Link from '../Link';
 import { joinUrls } from '../../utils/url';
 
 const Wrapper = styled.aside`
-  width: 24%;
-  padding-right: 2.5em;
+  display: none;
+  ${({ theme }) => theme.media.medLarge`
+    display: block;
+    width: 24%;
+    padding-right: 2.5em;
 
-  > ul {
-    margin-left: -3.5em;
+    > ul {
+      margin-left: -3.5em;
 
-    ${({ theme }) => theme.media.medLarge`
-      margin-left: -6.25em;
-    `}
-  }
-
-  ul {
-    list-style-type: none;
-    padding: 0;
+      ${({ theme }) => theme.media.medLarge`
+        margin-left: -6.25em;
+      `}
+    }
 
     ul {
-      li:last-child {
-        margin-bottom: 1.3em;
+      list-style-type: none;
+      padding: 0;
+
+      ul {
+        li:last-child {
+          margin-bottom: 1.3em;
+        }
+
+        a {
+          color: #6b6b6b;
+          font-weight: normal;
+          padding: 0.4em 0.625em 0.4em 5.375em;
+          margin: 0;
+        }
       }
 
       a {
-        color: #6b6b6b;
-        font-weight: normal;
-        padding: 0.4em 0.625em 0.4em 5.375em;
-        margin: 0;
-      }
-    }
-
-    a {
-      display: inline-block;
-      color: #000;
-      font-weight: bold;
-      line-height: 1;
-      padding: 0.875em 1em 0.875em 3.5em;
-      margin-bottom: 0.3em;
-
-      &:hover {
-        color: #a043b6;
-      }
-
-      &.active {
-        background: #f3e5f7;
+        display: inline-block;
         color: #000;
+        font-weight: bold;
+        line-height: 1;
+        padding: 0.875em 1em 0.875em 3.5em;
+        margin-bottom: 0.3em;
+
+        &:hover {
+          color: #a043b6;
+        }
+
+        &.active {
+          background: #f3e5f7;
+          color: #000;
+        }
       }
     }
-  }
+  `}
 `;
 
 const renderNavItems = (path, items) => (


### PR DESCRIPTION
responsive getting started page

  * remove left table of contents, adjust padding in the hero

---

set google analytics cookieExpires field to 0

  * https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/#optional-fields
  * https://developers.google.com/analytics/devguides/collection/gtagjs/cookies-user-id#cookie_expiration

> If you set the cookie_expires value to 0 (zero) seconds, the cookie turns into a session based cookie and expires once the current browser session ends.